### PR TITLE
Add memoize_class_method

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ class Foo
   memoize def bar(value)
     expensive_calculation(value)
   end
+
+  memoize_class_method def self.baz(value)
+    expensive_calculation(value)
+  end
 end
 ```
 

--- a/lib/memoit.rb
+++ b/lib/memoit.rb
@@ -21,6 +21,10 @@ module Memoit
     end
     prepend mod
   end
+
+  def memoize_class_method(name)
+    singleton_class.memoize(name)
+  end
 end
 
 Module.send(:include, Memoit)

--- a/lib/memoit.rb
+++ b/lib/memoit.rb
@@ -22,6 +22,14 @@ module Memoit
     prepend mod
   end
 
+  # Memoize the class method with the given name.
+  #
+  # @example
+  #   class Foo
+  #     memoize_class_method def self.bar(value)
+  #       expensive_calculation(value)
+  #     end
+  #   end
   def memoize_class_method(name)
     singleton_class.memoize(name)
   end

--- a/spec/memoit_spec.rb
+++ b/spec/memoit_spec.rb
@@ -3,6 +3,10 @@ require "memoit"
 describe Memoit do
   let(:klass) do
     Class.new do
+      memoize_class_method def self.foo
+        rand
+      end
+
       memoize def foo
         rand
       end
@@ -40,6 +44,12 @@ describe Memoit do
     it "caches falsy values" do
       expect(instance).to receive(:foo).once
       expect(instance.falsy).to eq(instance.falsy)
+    end
+  end
+
+  describe ".memoize_class_method" do
+    it "caches result" do
+      expect(klass.foo).to eq(klass.foo)
     end
   end
 end


### PR DESCRIPTION
Since `memoize` can't tell a class method from an instance method.

The naming was chosen to be consistent with `private`/`private_class_method`.