### PR TITLE
Add documentation and tests for alternative notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ class Foo
 end
 ```
 
+You can also use the more familiar, standalone notation:
+
+``` ruby
+class Foo
+  def bar(value)
+    expensive_calculation(value)
+  end
+  memoize :bar
+
+  def self.baz(value)
+    expensive_calculation(value)
+  end
+  memoize_class_method :baz
+end
+```
+
 ## Is it any good?
 
 [Yes](https://news.ycombinator.com/item?id=3067434).

--- a/spec/support/shared_examples/memoizer.rb
+++ b/spec/support/shared_examples/memoizer.rb
@@ -1,0 +1,45 @@
+shared_examples "memoizer" do
+  context "when memoizing a class method" do
+    it "caches result" do
+      expect(klass.foo).to eq(klass.foo)
+    end
+  end
+
+  context "when memoizing an instance method" do
+    let(:instance) { klass.new }
+
+    it "caches result" do
+      expect(instance.foo).to eq(instance.foo)
+    end
+
+    it "caches results for different parameters" do
+      a = Object.new
+      expect(instance.bar(1)).to eq(instance.bar(1))
+      expect(instance.bar(2)).to eq(instance.bar(2))
+      expect(instance.bar(a, 1, :foo, "bar")).to eq(instance.bar(a, 1, :foo, "bar"))
+      expect(instance.bar(2)).not_to eq(instance.bar(1))
+      expect(instance.bar(a, 1, :foo, "bar")).not_to eq(instance.bar(Object.new, 1, :foo, "bar"))
+    end
+
+    it "ignores cache when block given" do
+      expect(instance.foo { }).not_to eq(instance.foo { })
+    end
+
+    it "caches falsy values" do
+      expect(instance).to receive(:foo).once
+      expect(instance.falsy).to eq(instance.falsy)
+    end
+
+    it "handles question-mark methods" do
+      expect(instance.query?).to eq(instance.query?)
+    end
+
+    it "handles bang methods" do
+      expect(instance.bang!).to eq(instance.bang!)
+    end
+
+    it "handles non-ASCII-name methods" do
+      expect(instance.☃).to eq(instance.☃)
+    end
+  end
+end


### PR DESCRIPTION
Memoit supports an alternative, `alias`-like notation out of the box:

```ruby
class Foo
  def bar; end
  memoize :bar
end
```

This change adds documentation and tests for this.

@jnicklas: As part of the change, I extracted a shared example for the tests. If you don't like this, please let me know your preference for organizing the tests, and I'll make changes accordingly. 😀 
