### PR TITLE
Allow explicit usage and make monkey-patch opt-in

### DIFF
--- a/lib/memoit.rb
+++ b/lib/memoit.rb
@@ -1,6 +1,11 @@
 require "memoit/version"
 
 module Memoit
+  def self.extended(klass)
+    unless klass.singleton_class?
+      klass.singleton_class.extend(self)
+    end
+  end
 
   # Memoize the method with the given name.
   #
@@ -36,5 +41,3 @@ module Memoit
     singleton_class.memoize(name)
   end
 end
-
-Module.send(:include, Memoit)

--- a/lib/memoit/core_ext.rb
+++ b/lib/memoit/core_ext.rb
@@ -1,0 +1,3 @@
+require "memoit"
+
+Module.send(:include, Memoit)

--- a/spec/integration/core_ext_spec.rb
+++ b/spec/integration/core_ext_spec.rb
@@ -1,6 +1,8 @@
-require "memoit"
+describe Memoit, "as core extension" do
+  before :all do
+    require "memoit/core_ext"
+  end
 
-describe Memoit do
   let(:klass) do
     Class.new do
       memoize_class_method def self.foo
@@ -73,6 +75,8 @@ describe Memoit do
     it "returns the name of the method" do
       name = nil
       Class.new do
+        extend Memoit
+
         name = memoize def blah
         end
       end
@@ -80,22 +84,26 @@ describe Memoit do
     end
 
     it "works in a mixin" do
-      mod = Module.new do
-        memoize def cname
-          self.class.name
+      module Test
+        Mod = Module.new do
+          extend Memoit
+
+          memoize def cname
+            self.class.name
+          end
+        end
+
+        Foo = Class.new do
+          include Mod
+        end
+
+        Bar = Class.new do
+          include Mod
         end
       end
 
-      Foo = Class.new do
-        include mod
-      end
-
-      Bar = Class.new do
-        include mod
-      end
-
-      expect(Foo.new.cname).to eq("Foo")
-      expect(Bar.new.cname).to eq("Bar")
+      expect(Test::Foo.new.cname).to eq("Test::Foo")
+      expect(Test::Bar.new.cname).to eq("Test::Bar")
     end
   end
 

--- a/spec/integration/extended_module_spec.rb
+++ b/spec/integration/extended_module_spec.rb
@@ -1,0 +1,113 @@
+describe Memoit, "as extended module" do
+  let(:klass) do
+    Class.new do
+      extend Memoit
+
+      memoize_class_method def self.foo
+        rand
+      end
+
+      memoize def foo
+        rand
+      end
+
+      memoize def bar(*values)
+        rand
+      end
+
+      memoize def falsy
+        foo
+        false
+      end
+
+      memoize def query?
+        rand
+      end
+
+      memoize def bang!
+        rand
+      end
+
+      memoize def ☃
+        rand
+      end
+    end
+  end
+  let(:instance) { klass.new }
+
+  describe ".memoize" do
+    it "caches result" do
+      expect(instance.foo).to eq(instance.foo)
+    end
+
+    it "caches results for different parameters" do
+      a = Object.new
+      expect(instance.bar(1)).to eq(instance.bar(1))
+      expect(instance.bar(2)).to eq(instance.bar(2))
+      expect(instance.bar(a, 1, :foo, "bar")).to eq(instance.bar(a, 1, :foo, "bar"))
+      expect(instance.bar(2)).not_to eq(instance.bar(1))
+      expect(instance.bar(a, 1, :foo, "bar")).not_to eq(instance.bar(Object.new, 1, :foo, "bar"))
+    end
+
+    it "ignores cache when block given" do
+      expect(instance.foo { }).not_to eq(instance.foo { })
+    end
+
+    it "caches falsy values" do
+      expect(instance).to receive(:foo).once
+      expect(instance.falsy).to eq(instance.falsy)
+    end
+
+    it "handles question-mark methods" do
+      expect(instance.query?).to eq(instance.query?)
+    end
+
+    it "handles bang methods" do
+      expect(instance.bang!).to eq(instance.bang!)
+    end
+
+    it "handles non-ASCII-name methods" do
+      expect(instance.☃).to eq(instance.☃)
+    end
+
+    it "returns the name of the method" do
+      name = nil
+      Class.new do
+        extend Memoit
+
+        name = memoize def blah
+        end
+      end
+      expect(name).to eq(:blah)
+    end
+
+    it "works in a mixin" do
+      module Test
+        Mod = Module.new do
+          extend Memoit
+
+          memoize def cname
+            self.class.name
+          end
+        end
+
+        Foo = Class.new do
+          include Mod
+        end
+
+        Bar = Class.new do
+          include Mod
+        end
+      end
+
+      expect(Test::Foo.new.cname).to eq("Test::Foo")
+      expect(Test::Bar.new.cname).to eq("Test::Bar")
+    end
+  end
+
+  describe ".memoize_class_method" do
+    it "caches result" do
+      expect(klass.foo).to eq(klass.foo)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,34 @@
+module TestNamespace
+  def remove_constants
+    constants.each do |name|
+      remove_const(name)
+    end
+  end
+end
+
+RSpec.configure do |config|
+  # Require memoit before each example group, and then undefine it (and allow it
+  # to be later re-required) afterwards. This allows us to test both explicit
+  # and core-ext (monkey-patched) usage
+  config.before :all do
+    @prev_loaded_features = $LOADED_FEATURES.dup
+    require "memoit"
+  end
+
+  config.after :all do
+    Object.send(:remove_const, :Memoit)
+
+    ($LOADED_FEATURES - @prev_loaded_features).each do |file|
+      $LOADED_FEATURES.delete(file)
+    end
+  end
+
+  # Create a `Test` module whose constants are cleared after each example
+  config.before :each do
+    Object.const_set(:Test, Module.new { |m| m.extend(TestNamespace) })
+  end
+
+  config.after :each do
+    Object.send(:remove_const, :Test)
+  end
+end


### PR DESCRIPTION
Hi @jnicklas —

I'm a huge fan of memoit. Of all the memoizing method gems, memoit seems to strike exactly the right balance of code readability and number of features.

The one thing I've always wanted, though, is the ability to explicitly opt into support for memoizing methods, rather than have it available everywhere by including Memoit module into `Module`.

In this PR, I've made this possible by splitting the behaviour up into 2 files:

- A simple `require "memoit"` just defines the `Memoit` module, nothing more. From here, if you want to use memoit inside a class, you must add `extend Memoit` to the class definition.
- A `require "memoit/core_ext"` (not required by default) will maintain the existing behaviour of including Memoit into `Module`, so it's available everywhere

I've updated the specs to verify both modes of usage work as intended (this required a little jiggery to get Ruby to clean its global state after monkey-patching Module).

I feel this would really round out the gem, and make it attractive to both kinds of Ruby developers, those who prefer the available-everywhere ergonomics of monkey-patching (or those would rather avoid it entirely!).

One thing to keep in mind here, however, is that you could consider this a "breaking" change, since existing users would need to add the `require "memoit/core_ext"` line to their applications.

Thanks for your consideration!