### PR TITLE
Interesting behavior on 2.7 with implicit hash conversion and keyword arguments

### DIFF
--- a/spec/memoit_spec.rb
+++ b/spec/memoit_spec.rb
@@ -11,6 +11,10 @@ describe Memoit do
         rand
       end
 
+      memoize def single_param(object)
+        object
+      end
+
       memoize def bar(*values)
         rand
       end
@@ -54,6 +58,12 @@ describe Memoit do
   describe ".memoize" do
     it "caches result" do
       expect(instance.foo).to eq(instance.foo)
+    end
+
+    it "does not convert objects to a hash implicitly" do
+      object = double(to_hash: {})
+
+      expect(instance.single_param(object)).to eq(object)
     end
 
     it "caches results for different parameters" do


### PR DESCRIPTION
Hi! This PR is a discussion PR, opened mostly for the benefit of others running into the same issue. This problem also goes away in Q1 2023 when Ruby 2.x is EOL.

In short, this PR fails on Ruby 2.7.

The conditions for failure are:
- Using Ruby 2.x
- Single-argument method (probably)
- Parameter passed responds to `to_hash`

Since memoit defines the memoized method with the following parameter list:
```ruby
define_method(…) do |*args, **kwargs, &block|
```

The single parameter is automatically converted to a hash.

A minimal example would be:
```ruby
class Foo; def to_hash; { x: "Haha" }; end; end

def foo(*a, **b)
  p [a, b]
end

foo(Foo.new) # => [[], {:x=>"Haha"}]
p RUBY_VERSION # => 2.7.x
```